### PR TITLE
Added Python 3.4 support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.1 (unreleased)
+----------------
+
+- Added Python 3.4 support.
+
+
 1.0 (2013-07-02)
 ----------------
 

--- a/pyramid_robot/layer.py
+++ b/pyramid_robot/layer.py
@@ -121,7 +121,7 @@ class ResourceManager(object):
     def _resourceResolutionOrder(self, instance):
         return self._mergeResourceManagers(
                 [ [instance] ] +
-                map(self._resourceResolutionOrder, instance.__bases__) +
+                list(map(self._resourceResolutionOrder, instance.__bases__)) +
                 [ list(instance.__bases__) ]
             )
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from setuptools import setup, find_packages
 
@@ -6,22 +7,30 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.rst')).read()
 CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
 
+PY3 = sys.version_info[0] == 3
+
 requires = [
     'pyramid',
     'WebTest',
     'robotsuite',
-    'robotframework',
     'robotframework-selenium2library',
     'decorator',
     'selenium'
 ]
 
+if PY3:
+    requires.append('robotframework-python3')
+else:
+    requires.append('robotframework')
+
 setup(name='pyramid_robot',
-      version='1.0',
+      version='1.1dev',
       description='Convenience package for enable RobotFramework tests under Pyramid.',
       long_description=README + '\n\n' + CHANGES,
       classifiers=[
           "Programming Language :: Python",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3.4",
           "Framework :: Pyramid",
           "Topic :: Internet :: WWW/HTTP",
           "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",


### PR DESCRIPTION
This is now compatible with both Python 2.7 and Python 3.4.
This uses robotframework-python3 with Python 3.

See https://github.com/rtomac/robotframework-selenium2library/pull/295
and https://github.com/collective/robotsuite/pull/7
